### PR TITLE
Better Java 21 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,5 +25,8 @@ jobs:
           java-version: ${{ matrix.java-version }}
           distribution: ${{ matrix.java-distro }}
 
+      - name: List JDKs available to Gradle
+        run: ./gradlew -q javaToolchains
+
       - name: Build and run tests
         run: ./gradlew test -i --console=plain --no-daemon

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest]
-        java-version: [18, 17, 16]
+        java-version: [21, 17]
         java-distro: [temurin, zulu]
 
     runs-on: ${{ matrix.os }}

--- a/build.gradle
+++ b/build.gradle
@@ -3,12 +3,9 @@ plugins {
     id 'eclipse'
 }
 
-var javaVersion = 17
-
 java {
-  toolchain {
-    languageVersion.set(JavaLanguageVersion.of(javaVersion))
-  }
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 repositories {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- CI now tests on 21
- Gradle no longer configured to download 17 if a newer version is available