### PR TITLE
ignore COLORTERM env variable when generating ANSI escape codes

### DIFF
--- a/src/edu/macalester/conceptual/context/ConsolePuzzlePrinter.java
+++ b/src/edu/macalester/conceptual/context/ConsolePuzzlePrinter.java
@@ -312,14 +312,7 @@ public class ConsolePuzzlePrinter implements PuzzlePrinter {
     }
 
     private String textColorCode(Color color, boolean foreground) {
-        String terminalColorMode = System.getenv("COLORTERM");
-        if (terminalColorMode != null && terminalColorMode.matches("truecolor|24bit")) {
-            // 24-bit (true color) ANSI code
-            // Only some terminals support it (VS Code = yes, Apple Terminal = no)
-            return ansiCode('m',
-                foreground ? 38 : 48, 2,
-                color.getRed(), color.getGreen(), color.getBlue());
-        } else {
+
             // 256-color ANSI code: better compatibility
             return ansiCode(
                 'm',
@@ -328,7 +321,7 @@ public class ConsolePuzzlePrinter implements PuzzlePrinter {
                 16  + scale256To6(color.getBlue())
                     + scale256To6(color.getGreen()) * 6
                     + scale256To6(color.getRed()) * 36);
-        }
+        
     }
 
     private String plainTextColorCode() {


### PR DESCRIPTION
Should fix #28.

The CI environment doesn't have COLORTERM set, so when running integration tests in a shell that does have it set to `truecolor` or `24bit` produces spurious failures because the generated escape codes are different, despite representing the same (or very nearly so) color.

You see failures like those noted in

<https://github.com/mac-comp127/conceptual-puzzles/pull/27#issuecomment-4868900355>

The diffs look like:

```
Diff (printing max 10 changes, 10 lines each):
11 → 11:
< ?[1m?[38;5;16m?[48;5;99m            ?[0m
< ?[1m?[38;5;16m?[48;5;99m   PART 1   ?[0m
< ?[1m?[38;5;16m?[48;5;99m            ?[0m
–––
> ?[1m?[38;2;0;0;0m?[48;2;106;51;255m            ?[0m
> ?[1m?[38;2;0;0;0m?[48;2;106;51;255m   PART 1   ?[0m
> ?[1m?[38;2;0;0;0m?[48;2;106;51;255m            ?[0m
```

The expected output specifies foreground color 16 and background color 99 from the 216-color table; see
<https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit>.

The actual output generated for 24-bit color specifies a foreground color of black -- RGB (0,0,0) -- and background with RGB (106,51,255). (See the 24-bit section from the above link.)